### PR TITLE
MA: Hate Speech

### DIFF
--- a/commands/user-timeout-hatespeech.js
+++ b/commands/user-timeout-hatespeech.js
@@ -1,7 +1,7 @@
 module.exports = {
-	name: 'Mod Action: Hate Speech',
+	name: 'MA: Hate Speech',
 	data: {
-		name: 'Mod Action: Hate Speech',
+		name: 'MA: Hate Speech',
 		type: 2,
 	},
 	async execute(interaction) {


### PR DESCRIPTION
Refactor module export and data property names

This commit changes the module export and data property names for handling user timeouts due to hate speech. The module export name has been changed from 'Mod Action: Hate Speech' to 'MA: Hate Speech', and the data property name has been changed accordingly.