### PR TITLE
Patch: Handle error when handling modal submission.

### DIFF
--- a/commands/message-report.js
+++ b/commands/message-report.js
@@ -59,6 +59,7 @@ module.exports = {
 			}
 		} catch (error) {
 			console.error('Error handling modal submission:', error);
+			await interaction.followUp({content: 'Modal Expired. Please press cancel and try again.', ephemeral: true});
 		}
 	},
 };


### PR DESCRIPTION
- Add error handling when handling modal submission in `message-report.js`.
- If an error occurs, log the error to the console.
- If an error occurs, display a message to the user indicating that the modal has expired.