### PR TITLE
feat: Add welcome message for new guild members

### DIFF
--- a/events/welcomeMessage.js
+++ b/events/welcomeMessage.js
@@ -1,0 +1,18 @@
+const {EmbedBuilder} = require('@discordjs/builders');
+
+module.exports = {
+	name: 'guildMemberAdd',
+	async execute(member) {
+		const welcomeMessage = new EmbedBuilder().setTitle('Welcome to Thin Blue Line RP').addFields(
+			{name: 'Member', value: member.displayName},
+		);
+
+		const {systemChannel} = member.guild;
+		console.log(systemChannel.id);
+		if (systemChannel) {
+			systemChannel.send({embeds: [welcomeMessage]});
+		} else {
+			console.error('System channel not found!');
+		}
+	},
+};

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 
 const token = process.env.DISCORD_TOKEN; // Access the bot token from the environment variable
 
-const client = new Client({intents: ['Guilds']});
+const client = new Client({intents: ['Guilds', 'GuildMembers']});
 
 const eventFiles = fs.readdirSync('./events').filter(file => file.endsWith('.js'));
 for (const file of eventFiles) {


### PR DESCRIPTION
In the `welcomeMessage.js` file, a new event handler named `guildMemberAdd` was implemented. When a new member joins the guild, a welcome message is created using an EmbedBuilder and sent to the system channel. If the system channel is not found, an error message is logged.

In the `index.js` file, the client is now initialized with the `GuildMembers` intent in addition to the `Guilds` intent.