### PR TITLE
Add conditional loading of environment variables in DEV environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-require('dotenv').config(); // Load environment variables from .env
+if (process.env.enviornment === 'DEV') {
+	require('dotenv').config(); // Load environment variables from .env
+}
 
 const {Client, Collection, GatewayIntentBits, Partials} = require('discord.js');
 const fs = require('fs');


### PR DESCRIPTION
Previously, environment variables were always loaded from the .env file. This change introduces a condition to only load them if the environment is set to DEV. This allows for better control and separation of environment configurations in different deployment scenarios.