### PR TITLE
Add Procfile: define process types and commands for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: npm start


### PR DESCRIPTION
- Procfile was created to specify the worker process type and the command to start it using npm.
- This file is used by Heroku to understand how to run the worker process.
- The process type "worker" is specified and the command "npm start" is assigned to it.
- The missing newline at the end of the file was also fixed.