### PR TITLE
Remove npm start command from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-worker: npm start


### PR DESCRIPTION
Chore: Removed the npm start command from the Procfile to streamline the project configuration and avoid redundancy in process definition. The Procfile now reflects the elimination of an unnecessary command, simplifying the project structure.